### PR TITLE
Force kill Xorg server when using GDM

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Usage
 
 Make sure the SystemD service `optimus-manager.service` is running, then run
 ```
+optimus-manager --switch auto
+```
+to switch to the not-using GPU,
+```
 optimus-manager --switch nvidia
 ```
 to switch to the Nvidia GPU, and
@@ -109,7 +113,7 @@ The Arch wiki can be a great resource for troubleshooting. Check the following p
 
 #### How can I check which GPU my X session is running on ?
 
-You can run `glxinfo | grep "server glx vendor string"`. If you see `SGI`, you are running on the Intel GPU. If you see `NVIDIA Corporation`, you are running on the Nvidia GPU.
+You can run `optimus-manager --print-mode`. Alternatively, you can run `glxinfo | grep "server glx vendor string"`. If you see `SGI`, you are running on the Intel GPU. If you see `NVIDIA Corporation`, you are running on the Nvidia GPU.
 
 #### When I switch GPUs, my system completely locks up (I cannot even switch to a TTY with Ctrl+Alt+F*x*)
 
@@ -153,7 +157,7 @@ If that does not fix your problem and you have to open a GitHub issue, please at
 
 #### GPU switching works but I cannot run any 3D application in Intel mode (they fail to launch with some error message)
 
-Check if the `nvidia` module is still loaded in Intel mode. That should not happen, but if it is the case, then logout, stop the display manager manually, unload all Nvidia modules (`nvidia`, `nvidia_modeset`,`nvidia_drm`, in that order) and restart the display manager.
+Check if the `nvidia` module is still loaded in Intel mode. That should not happen, but if it is the case, then logout, stop the display manager manually, unload all Nvidia modules (`nvidia_drm`, `nvidia_modeset`, `nvidia-uvm`, and `nvidia`, in that order) and restart the display manager.
 
 Consider opening a GitHub issue about this, with logs attached.
 

--- a/optimus_manager/checks.py
+++ b/optimus_manager/checks.py
@@ -19,14 +19,16 @@ def are_nvidia_modules_loaded():
     ret1 = exec_bash("lsmod | grep nvidia_drm").returncode
     ret2 = exec_bash("lsmod | grep nvidia_modeset").returncode
     ret3 = exec_bash("lsmod | grep nvidia").returncode
-    return (ret1 == 0) and (ret2 == 0) and (ret3 == 0)
+    ret4 = exec_bash("lsmod | grep nvidia_uvm").returncode
+    return (ret1 == 0) and (ret2 == 0) and (ret3 == 0) and (ret4 == 0)
 
 
 def are_nvidia_modules_unloaded():
     ret1 = exec_bash("lsmod | grep nvidia_drm").returncode
     ret2 = exec_bash("lsmod | grep nvidia_modeset").returncode
     ret3 = exec_bash("lsmod | grep nvidia").returncode
-    return (ret1 != 0) and (ret2 != 0) and (ret3 != 0)
+    ret4 = exec_bash("lsmod | grep nvidia_uvm").returncode
+    return (ret1 != 0) and (ret2 != 0) and (ret3 != 0) and (ret4 != 0)
 
 
 def is_gpu_powered():
@@ -41,14 +43,6 @@ def is_login_manager_active(config):
     return (state == "active")
 
 
-def is_xorg_running():
-
-    ret1 = exec_bash("pidof X").returncode
-    ret2 = exec_bash("pidof Xorg").returncode
-
-    return (ret1 == 0) or (ret2 == 0)
-
-
 def is_pat_available():
     ret = exec_bash("grep -E '^flags.+ pat( |$)' /proc/cpuinfo").returncode
     return (ret == 0)
@@ -58,7 +52,7 @@ def read_gpu_mode():
 
     ret = exec_bash("glxinfo").returncode
     if ret != 0:
-        raise CheckError("Cannot find current mode because mesa_demos is not installed")
+        raise CheckError("Cannot find the current mode")
     else:
         ret = exec_bash("glxinfo | grep NVIDIA").returncode
         if ret == 0:

--- a/optimus_manager/login_managers.py
+++ b/optimus_manager/login_managers.py
@@ -1,5 +1,4 @@
 import os
-import time
 import optimus_manager.envs as envs
 from optimus_manager.detection import get_login_managers
 import optimus_manager.checks as checks
@@ -18,9 +17,7 @@ def restart_login_manager(config):
         print("Login manager control is disabled, not restarting it.")
         return
 
-    exec_bash("systemctl stop display-manager")
-    _wait_xorg_stop()
-    exec_bash("systemctl start display-manager")
+    exec_bash("systemctl restart display-manager")
 
     if not checks.is_login_manager_active(config):
         raise LoginManagerError("Warning : cannot restart service display-manager.")
@@ -137,20 +134,3 @@ def _configure_gdm(mode):
 
         except IOError:
             raise LoginManagerError("Cannot write to %s" % filepath)
-
-
-def _wait_xorg_stop():
-
-    POLL_TIME = 0.5
-    TIMEOUT = 10.0
-
-    t0 = time.time()
-    t = t0
-    while abs(t-t0) < TIMEOUT:
-        if not checks.is_xorg_running():
-            return True
-        else:
-            time.sleep(POLL_TIME)
-            t = time.time()
-
-    return False

--- a/optimus_manager/optimus_manager_client.py
+++ b/optimus_manager/optimus_manager_client.py
@@ -35,7 +35,7 @@ def main():
                         help="Print the current mode.")
     parser.add_argument('--switch', metavar='MODE', action='store',
                         help="Set the GPU mode to MODE and restart the display manager. "
-                             "Possible modes : intel, nvidia, auto (checks the current mode and switch to the other) "
+                             "Possible modes : intel, nvidia, auto (checks the current mode and switch to the other). "
                              "WARNING : All your applications will close ! Be sure to save your work.")
     parser.add_argument('--set-startup', metavar='STARTUP_MODE', action='store',
                         help="Set the startup mode to STARTUP_MODE. Possible modes : "

--- a/optimus_manager/switching.py
+++ b/optimus_manager/switching.py
@@ -17,7 +17,7 @@ def switch_to_intel(config):
 
     # Nvidia modules
     print("Unloading Nvidia modules")
-    exec_bash("rmmod nvidia_drm nvidia_modeset nvidia")
+    exec_bash("rmmod nvidia_drm nvidia_modeset nvidia_uvm nvidia")
     if not checks.are_nvidia_modules_unloaded():
         raise SwitchError("Cannot unload Nvidia modules")
 
@@ -93,9 +93,9 @@ def switch_to_nvidia(config):
               "Disabling the PAT option for Nvidia.")
         pat_value = 0
 
-    exec_bash("modprobe nvidia_drm modeset=%d" % modeset_value)
-    exec_bash("modprobe nvidia_modeset")
     exec_bash("modprobe nvidia NVreg_UsePageAttributeTable=%d" % pat_value)
+    exec_bash("modprobe nvidia_uvm nvidia_modeset")
+    exec_bash("modprobe nvidia_drm modeset=%d" % modeset_value)
 
     if not checks.are_nvidia_modules_loaded():
         raise SwitchError("Cannot load Nvidia modules")


### PR DESCRIPTION
This is the solution for stopping X servers in GDM: we force stop them. Note that `gdm.service` must remain intact, or else we'll have to manually switch to a different virtual terminal before switching back to tty1 for the login screen to appear. (#4)