### PR TITLE
[Feature request] Add auto mode check capability

### DIFF
--- a/optimus_manager/optimus_manager_client.py
+++ b/optimus_manager/optimus_manager_client.py
@@ -30,8 +30,11 @@ def main():
     parser = argparse.ArgumentParser(description="Client program for the Optimus Manager tool.\n"
                                                  "https://github.com/Askannz/optimus-manager")
     parser.add_argument('-v', '--version', action='store_true', help='Print version and exit.')
+    parser.add_argument('--print-mode', action='store_true',
+                        help="Print the current mode.")
     parser.add_argument('--switch', metavar='MODE', action='store',
-                        help="Set the GPU mode to MODE (\"intel\" or \"nvidia\") and restart the display manager."
+                        help="Set the GPU mode to MODE and restart the display manager."
+                             "Possible modes : intel, nvidia, auto (checks the current mode and switch to the other"
                              "WARNING : All your applications will close ! Be sure to save your work.")
     parser.add_argument('--set-startup', metavar='STARTUP_MODE', action='store',
                         help="Set the startup mode to STARTUP_MODE. Possible modes : "
@@ -48,6 +51,16 @@ def main():
         print("Optimus Manager (Client) version %s" % envs.VERSION)
         sys.exit(0)
 
+    elif args.print_mode:
+
+        try:
+            mode = var.read_mode()
+        except var.VarError as e:
+            print("Error reading mode : %s" % str(e))
+            sys.exit(1)
+
+        print("Current mode : %s" % mode)
+
     elif args.print_startup:
 
         try:
@@ -60,9 +73,22 @@ def main():
 
     elif args.switch:
 
-        if args.switch not in ["intel", "nvidia"]:
+        if args.switch not in ["auto", "intel", "nvidia"]:
             print("Invalid mode : %s" % args.switch)
             sys.exit(1)
+        
+        if args.switch == "auto":
+            try:
+                mode = var.read_mode()
+            except var.VarError as e:
+                print("Error reading mode: %s" % str(e))
+                sys.exit(1)
+            
+            if mode == "nvidia":
+                args.switch = "intel"
+            else:
+                args.switch = "nvidia"
+            print("Switching to : %s" % args.switch)
 
         if args.no_confirm:
             send_command(args.switch)
@@ -74,7 +100,7 @@ def main():
 
             if ans == "y":
                 send_command(args.switch)
-            elif ans == "n":
+            elif ans == "n" or ans == "N":
                 print("Aborting.")
             else:
                 print("Invalid choice. Aborting")

--- a/optimus_manager/optimus_manager_client.py
+++ b/optimus_manager/optimus_manager_client.py
@@ -33,8 +33,8 @@ def main():
     parser.add_argument('--print-mode', action='store_true',
                         help="Print the current mode.")
     parser.add_argument('--switch', metavar='MODE', action='store',
-                        help="Set the GPU mode to MODE and restart the display manager."
-                             "Possible modes : intel, nvidia, auto (checks the current mode and switch to the other"
+                        help="Set the GPU mode to MODE and restart the display manager. "
+                             "Possible modes : intel, nvidia, auto (checks the current mode and switch to the other) "
                              "WARNING : All your applications will close ! Be sure to save your work.")
     parser.add_argument('--set-startup', metavar='STARTUP_MODE', action='store',
                         help="Set the startup mode to STARTUP_MODE. Possible modes : "

--- a/optimus_manager/var.py
+++ b/optimus_manager/var.py
@@ -1,9 +1,22 @@
 import os
 import optimus_manager.envs as envs
+from optimus_manager.bash import exec_bash
 
 
 class VarError(Exception):
     pass
+
+
+def read_mode():
+    ret = exec_bash("glxinfo").returncode
+    if ret != 0:
+        raise VarError("Cannot find current mode because mesa_demos is not installed")
+    else:
+        ret = exec_bash("glxinfo | grep NVIDIA").returncode
+        if ret == 0:
+            return "nvidia"
+        else:
+            return "intel"
 
 
 def read_startup_mode():


### PR DESCRIPTION
We can check the current mode (either *nvidia* or *intel*) by executing `glxinfo | grep NVIDIA` and see if the output is non-empty or not (or to check if the return code is 0 or 1). This leads to another switching feature that is able to switch to the other mode (*intel* to *nvidia* or vice versa).

However, to be able to check the current mode, the client first needs to install `glxinfo` or `mesa_demos` package.