### PR TITLE
Move X servers killing from the starting of login managers to the stopping of them

### DIFF
--- a/optimus_manager/envs.py
+++ b/optimus_manager/envs.py
@@ -19,5 +19,3 @@ USER_CONFIG_PATH = "/etc/optimus-manager/optimus-manager.conf"
 
 EXTRA_XORG_OPTIONS_INTEL_PATH = "/etc/optimus-manager/xorg-intel.conf"
 EXTRA_XORG_OPTIONS_NVIDIA_PATH = "/etc/optimus-manager/xorg-nvidia.conf"
-
-XORG_KILL_DELAY = 0.5

--- a/optimus_manager/optimus_manager_setup.py
+++ b/optimus_manager/optimus_manager_setup.py
@@ -90,7 +90,7 @@ def main():
 
         # Kill Xorg servers
         print("Stopping X servers")
-        exec_bash("for pid in $(pidof Xorg); do kill $pid; done;")
+        exec_bash("for pid in $(pidof Xorg); do kill -9 $pid; done;")
         stopped = _wait_xorg_stop()
         if not stopped:
             print("Cannot stop X servers !")

--- a/optimus_manager/optimus_manager_setup.py
+++ b/optimus_manager/optimus_manager_setup.py
@@ -47,14 +47,6 @@ def main():
         # Config
         config = load_config()
 
-        # Kill Xorg servers
-        exec_bash("for pid in $(pidof Xorg); do kill $pid; done;")
-        time.sleep(envs.XORG_KILL_DELAY)
-        stopped = _wait_xorg_stop()
-        if not stopped:
-            print("Cannot stop the X server !")
-            sys.exit(1)
-
         # Cleanup
         clean_all()
 
@@ -95,6 +87,14 @@ def main():
 
         print("Cleaning up Optimus configuration")
         clean_all()
+
+        # Kill Xorg servers
+        print("Stopping X servers")
+        exec_bash("for pid in $(pidof Xorg); do kill $pid; done;")
+        stopped = _wait_xorg_stop()
+        if not stopped:
+            print("Cannot stop X servers !")
+            sys.exit(1)
 
     else:
 


### PR DESCRIPTION
A little of backstory, after adding the X server killing, my graphics switching has been inconsistent. Sometimes the application worked fine, sometimes it would need manual intervention or even hard shutting down. Also, my PC has a big performance hit _everytime_ I use the application, which is not the case when I used `nvidia_xrun`.

This commit removes the annoying race between optimus_manager_setup killing X servers and the login manager respawning these X servers. This race is probably the cause of such behaviors, including the performance hog. Also, this removes the `XORG_KILLING_DELAY` variable, since it might be a consequence of the race itself.

EDIT: Actually, after rebooting a few times, the inconsistency is back. At least this time there's no more performance hog of any kind. And I also think that the behavior should be _exactly the same_ as before this commit.