### PR TITLE
Make use of loginctl's terminate-session instead of Xorg killings

### DIFF
--- a/optimus_manager/optimus_manager_setup.py
+++ b/optimus_manager/optimus_manager_setup.py
@@ -91,9 +91,11 @@ def main():
         print("Cleaning up Optimus configuration")
         clean_all()
 
-        # Kill Xorg servers
-        print("Stopping X servers")
-        exec_bash("for pid in $(pidof Xorg); do kill -9 $pid; done;")
+        # Terminate user processes
+        print("Terminating user processes")
+        exec_bash("for user in $(loginctl list-users --no-legend | awk '{print $2}'); do loginctl terminate-user $user; done;")
+        exec_bash("for user in $(loginctl list-users --no-legend | awk '{print $2}'); do loginctl kill-user $user -s SIGKILL; done;")
+
         stopped = _wait_xorg_stop()
         if not stopped:
             print("Cannot stop X servers !")

--- a/optimus_manager/optimus_manager_setup.py
+++ b/optimus_manager/optimus_manager_setup.py
@@ -96,6 +96,9 @@ def main():
         exec_bash("for user in $(loginctl list-users --no-legend | awk '{print $2}'); do loginctl terminate-user $user; done;")
         exec_bash("for user in $(loginctl list-users --no-legend | awk '{print $2}'); do loginctl kill-user $user -s SIGKILL; done;")
 
+        # Stopping systemd-logind service
+        exec_bash("systemctl stop systemd-logind")
+
         stopped = _wait_xorg_stop()
         if not stopped:
             print("Cannot stop X servers !")

--- a/optimus_manager/optimus_manager_setup.py
+++ b/optimus_manager/optimus_manager_setup.py
@@ -93,11 +93,18 @@ def main():
 
         # Terminate user processes
         print("Terminating user processes")
-        exec_bash("for user in $(loginctl list-users --no-legend | awk '{print $2}'); do loginctl terminate-user $user; done;")
-        exec_bash("for user in $(loginctl list-users --no-legend | awk '{print $2}'); do loginctl kill-user $user -s SIGKILL; done;")
+        try:
+            exec_bash("for user in $(loginctl list-users --no-legend | awk '{print $2}'); do loginctl terminate-user $user; done;")
+            exec_bash("for user in $(loginctl list-users --no-legend | awk '{print $2}'); do loginctl kill-user $user -s SIGKILL; done;")
+        except BashError:
+            print("Cannot terminate user processes. Skipping ...")
+            pass
 
         # Stopping systemd-logind service
-        exec_bash("systemctl stop systemd-logind")
+        try:
+            exec_bash("systemctl stop systemd-logind")
+        except BashError:
+            pass
 
         stopped = _wait_xorg_stop()
         if not stopped:


### PR DESCRIPTION
Firstly, this safely remove the current loginctl session, which the previous method of Xorg killings couldn't do.

Secondly, this safely terminates the user's processes before abruptly killing more "stubborn" processes such as X servers. This may be a safer approach comparing to killing the X servers only.

Also by stopping the systemd-logind service, we may prevent nvidia_drm module refusing to stop, which makes switching from nvidia to intel mode difficult ([source](https://github.com/Witko/nvidia-xrun/issues/32)).