### PR TITLE
Add a systray

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ optimus-manager --set-startup MODE
 
 Where `MODE` can be `intel`, `nvidia`, or `nvidia_once`. The last one is a special mode which makes your system use the Nvidia GPU at boot, but for one boot only. After that it reverts to `intel` mode. This can be useful to test your Nvidia configuration and make sure you do not end up with an unusable X server.
 
+#### System Tray Icon
+optimus-manager includes a system tray icon that makes it easy to switch GPUs. It should work on most desktop environments.
+
+To make the tray icon automatically launch with your DE, it is usually enough to do:
+```
+ln -s /usr/share/applications/optimus-manager-systray.desktop ~/.config/autostart/optimus-manager-systray.desktop
+```
+
 Configuration
 ----------
 

--- a/desktop/optimus-manager-systray.desktop
+++ b/desktop/optimus-manager-systray.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=optimus-manager-systray
+Type=Application
+Exec=/usr/bin/python -u /usr/bin/optimus-manager-systray
+Terminal=false

--- a/icon/intel.svg
+++ b/icon/intel.svg
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="100"
+   inkscape:export-xdpi="100"
+   inkscape:export-filename="/home/alecive/Scrivania/firefoxTest1.png"
+   sodipodi:docname="intel.svg"
+   inkscape:version="0.48.4 r9939"
+   version="1.1"
+   id="svg2"
+   height="512"
+   width="512">
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.64397465"
+     inkscape:cx="360.56459"
+     inkscape:cy="155.57953"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="false"
+     inkscape:window-width="1375"
+     inkscape:window-height="876"
+     inkscape:window-x="1431"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:object-paths="false"
+     inkscape:snap-intersection-paths="false"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-nodes="true" />
+  <defs
+     id="defs4">
+    <linearGradient
+       x1="19.244999"
+       y1="21.030804"
+       x2="19.360001"
+       gradientUnits="userSpaceOnUse"
+       y2="44.984001"
+       id="linearGradient2460">
+      <stop
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1;"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4114-2-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0317796,0,0,1.0317796,-830.86406,592.67791)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       x1="45.447727"
+       y1="92.539597"
+       x2="45.447727"
+       y2="7.0165396"
+       id="ButtonShadow-0-1-1-5-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0058652,0,0,0.994169,100,0)">
+      <stop
+         id="stop3750-8-9-3-6-4"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-5-6-4-2-9"
+         style="stop-color:#000000;stop-opacity:0.58823532"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4112-2-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0402541,0,0,1.0402541,-837.95116,592.51825)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4110-6-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.023305,0,0,1.023305,-823.77704,592.83757)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4116-6-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0148305,0,0,1.0148305,-816.68996,592.99723)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       y2="20.625916"
+       x2="1006.8082"
+       y1="484.41721"
+       x1="1012.5133"
+       gradientTransform="matrix(1.0074153,0,0,1.0074153,-810.48879,593.1369)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5342-3"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3737-9"
+       id="linearGradient4084-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(778.59979,-360.55963)"
+       x1="993.43896"
+       y1="51.511765"
+       x2="988.78552"
+       y2="363.73825" />
+    <linearGradient
+       id="linearGradient3737-9">
+      <stop
+         id="stop3739-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3741-4"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4046-3"
+       id="linearGradient4086-12"
+       gradientUnits="userSpaceOnUse"
+       x1="1764.6487"
+       y1="155.59685"
+       x2="1763.6903"
+       y2="-55.941216" />
+    <linearGradient
+       id="linearGradient4046-3">
+      <stop
+         id="stop4048-7"
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4050-73"
+         style="stop-color:#ffffff;stop-opacity:0.2"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="36.643665"
+       x2="19.360001"
+       y1="6.2951212"
+       x1="18.930269"
+       gradientTransform="matrix(12.102564,0,0,12.102564,-34.468255,-46.187105)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3157"
+       xlink:href="#linearGradient2460"
+       inkscape:collect="always" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Livello 1"
+     transform="translate(0,-540.36218)" />
+  <g
+     id="g2036"
+     transform="matrix(1.1,0,0,0.44444,95.081063,256.39254)">
+    <g
+       id="g3712"
+       style="opacity:0.4"
+       transform="matrix(1.0526,0,0,1.2857,-1.2632,-13.429)" />
+  </g>
+  <g
+     transform="translate(97.481063,231.28154)"
+     id="g3541" />
+  <g
+     transform="translate(97.481063,231.28154)"
+     id="g3536" />
+  <g
+     id="g4103"
+     transform="translate(-11.985071,-592.11719)">
+    <rect
+       ry="101.45834"
+       y="612.11719"
+       x="31.985071"
+       height="487"
+       width="487"
+       id="rect6187"
+       style="opacity:0.1;color:#000000;fill:url(#linearGradient4114-2-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="opacity:0.07999998;color:#000000;fill:url(#linearGradient4112-2-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect6191"
+       width="491"
+       height="491"
+       x="31.985071"
+       y="612.11719"
+       ry="102.29167" />
+    <rect
+       style="opacity:0.2;color:#000000;fill:url(#linearGradient4110-6-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect6183"
+       width="483"
+       height="483"
+       x="31.985071"
+       y="612.11719"
+       ry="100.62501" />
+    <rect
+       ry="99.791664"
+       y="612.11719"
+       x="31.985071"
+       height="479"
+       width="479"
+       id="rect6179"
+       style="opacity:0.25;color:#000000;fill:url(#linearGradient4116-6-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="opacity:0.25;color:#000000;fill:url(#linearGradient5342-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5574"
+       width="475.5"
+       height="475.5"
+       x="31.985071"
+       y="612.11719"
+       ry="99.0625" />
+  </g>
+  <path
+     style="fill:url(#linearGradient3157);stroke:none"
+     d="M 118.34375,20 C 63.867087,20 20,63.867084 20,118.34375 l 0,23.0625 0,252.25 C 20,448.13291 63.867087,492 118.34375,492 l 275.3125,0 C 448.13292,492 492,448.13291 492,393.65625 l 0,-252.25 0,-23.0625 C 492,63.867084 448.13292,20 393.65625,20 l -275.3125,0 z"
+     id="rect5505"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#000000;fill-opacity:0.15686275"
+     d="M 361.125 185.59375 L 361.125 250.6875 L 339.03125 228.6875 C 333.18465 222.04742 324.9173 218.0625 314.5625 218.0625 C 303.1789 218.0625 293.241 222.28555 286.375 230.1875 L 255.78125 197.1875 L 235.34375 197.1875 L 235.34375 248.03125 L 214.6875 227.4375 C 210.8902 222.72624 204.8298 219.46875 195.75 219.46875 L 165.0625 219.46875 L 135.0625 188.375 L 114.34375 188.375 L 114.34375 208.125 L 126.34375 219.46875 L 114.34375 219.46875 L 114.34375 280 C 114.34375 286.76762 116.34918 292.99264 121.59375 297.09375 L 316.5 492 L 393.65625 492 C 448.13292 492 492 448.13291 492 393.65625 L 492 295.78125 L 381.8125 185.59375 L 361.125 185.59375 z M 313.65625 235.09375 C 324.20402 235.09375 328.20371 243.62965 328.65625 252.53125 L 296.90625 252.53125 C 297.12977 248.88685 297.61319 246.65286 298.96875 243.6875 C 301.23005 238.76741 306.65152 235.09375 313.65625 235.09375 z "
+     id="path3281" />
+  <g
+     id="g4076"
+     transform="translate(-605.51932,-353.96833)">
+    <g
+       transform="translate(-926.66758,684.38448)"
+       id="g4038" />
+  </g>
+  <g
+     id="g4076-9"
+     transform="translate(-605.51937,-353.96833)">
+    <g
+       transform="translate(-926.66758,684.38448)"
+       id="g4038-9">
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.5;color:#000000;fill:url(#linearGradient4084-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m 1650.4994,-310.41615 c -54.4767,0 -98.3125,43.83583 -98.3125,98.3125 l 0,275.343747 c 0,54.476673 43.8358,98.343753 98.3125,98.343753 l 2.9375,0 c -53.3225,0 -96.25,-42.9275 -96.25,-96.250003 l 0,-269.499997 c 0,-53.3225 42.9275,-96.25 96.25,-96.25 l 269.5001,0 c 53.3225,0 96.25,42.9275 96.25,96.25 l 0,269.499997 c 0,53.322503 -42.9275,96.250003 -96.25,96.250003 l 2.9062,0 c 54.4767,0 98.3438,-43.86708 98.3438,-98.343753 l 0,-275.343747 c 0,-54.47667 -43.8671,-98.3125 -98.3438,-98.3125 l -275.3438,0 z"
+         id="rect6809-2-3" />
+      <path
+         id="path3981-7"
+         d="m 1650.4994,161.58385 c -54.4767,0 -98.3125,-43.83583 -98.3125,-98.312503 l 0,-275.343747 c 0,-54.47667 43.8358,-98.34375 98.3125,-98.34375 l 2.9375,0 c -53.3225,0 -96.25,42.9275 -96.25,96.25 l 0,269.499997 c 0,53.322503 42.9275,96.250003 96.25,96.250003 l 269.5001,0 c 53.3225,0 96.25,-42.9275 96.25,-96.250003 l 0,-269.499997 c 0,-53.3225 -42.9275,-96.25 -96.25,-96.25 l 2.9062,0 c 54.4767,0 98.3438,43.86708 98.3438,98.34375 l 0,275.343747 c 0,54.476673 -43.8671,98.312503 -98.3438,98.312503 l -275.3438,0 z"
+         style="opacity:0.2;color:#000000;fill:url(#linearGradient4086-12);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <path
+     style="fill:#127cc1;fill-opacity:1"
+     id="path6"
+     d="m 454.2421,198.84575 c -18.83424,-91.8091 -196.48391,-97.6233 -310.998,-27.67687 l 0,7.72528 c 114.36371,-59.03189 276.64015,-58.65544 291.40703,25.91526 4.97585,28.01629 -10.69611,57.1544 -38.7964,73.92016 l 0,21.94085 c 33.82671,-12.41147 68.404,-52.58206 58.38737,-101.82468 M 246.00594,359.58919 C 166.97693,366.9037 84.632524,355.39054 73.104483,293.3936 67.379428,262.86554 81.316434,230.4641 99.700182,210.36097 l 0,-10.76367 c -33.149264,29.17788 -51.155672,66.08378 -40.758967,109.66034 13.258878,55.92011 83.926235,87.57343 191.811565,77.03399 42.71609,-4.1239 98.61861,-17.92598 137.415,-39.33745 l 0,-30.41973 c -35.25746,21.11388 -93.57031,38.55781 -142.16184,43.05474 z"
+     inkscape:connector-curvature="0" />
+  <path
+     id="path8"
+     d="m 361.10984,185.59234 0,92.68116 c 0,10.88516 5.19698,20.32404 20.71446,21.82492 l 0,-114.50608 -20.71446,0 z m -246.77963,2.77616 0,19.73212 20.71446,0 0,-19.73212 -20.71446,0 z m 120.99805,8.7983 0,80.42334 c 0,11.56489 7.0765,23.27707 23.87501,23.27707 l 12.1297,0 0,-17.21222 -8.3712,0 c -4.89518,0 -7.17532,-2.57355 -7.17532,-7.30345 l 0,-40.23302 15.54652,0 0,-16.65698 -15.54652,0 0,-22.29474 -20.45819,0 z m 79.22745,20.8853 c -21.62261,0 -38.05481,15.17853 -38.05481,42.02685 0,31.39491 18.86256,42.15498 38.52462,42.15498 15.06766,0 23.55422,-4.86471 31.69098,-12.89848 l -12.64223,-12.21512 c -5.27388,5.21532 -9.80291,7.77326 -18.92062,7.77326 -11.60256,0 -18.23726,-7.76983 -18.23726,-18.32269 l 52.14917,0 0,-7.43157 c 0,-23.32064 -12.58649,-41.08723 -34.50985,-41.08723 z m -200.2255,1.40944 0,60.52037 c 0,10.88928 5.19563,20.36743 20.71446,21.86763 l 0,-82.388 -20.71446,0 z m 38.99443,0 0,81.49109 20.50091,0 0,-64.83411 17.04137,0 c 6.02584,0 8.49933,2.97209 8.49933,7.81597 l 0,57.01814 20.58633,0 0,-57.10356 c 0,-11.60402 -6.21165,-24.38753 -24.21669,-24.38753 l -42.41125,0 z m 160.33415,15.63194 c 10.54777,0 14.53875,8.52416 14.99129,17.42576 l -31.73369,0 c 0.22352,-3.6444 0.69453,-5.87565 2.05009,-8.84101 2.2613,-4.92009 7.68758,-8.58475 14.69231,-8.58475 z"
+     style="fill:#127cc1;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/icon/nvidia.svg
+++ b/icon/nvidia.svg
@@ -1,0 +1,544 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="512"
+   height="512"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.3.1 r9886"
+   sodipodi:docname="nvidia.svg"
+   inkscape:export-filename="/home/alecive/Scrivania/firefoxTest1.png"
+   inkscape:export-xdpi="100"
+   inkscape:export-ydpi="100">
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.62568921"
+     inkscape:cx="30.867009"
+     inkscape:cy="192.62674"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2"
+     showgrid="false"
+     inkscape:window-width="1301"
+     inkscape:window-height="744"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:object-paths="false"
+     inkscape:snap-intersection-paths="false"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-nodes="true" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient8785">
+      <stop
+         id="stop8787"
+         style="stop-color:#2c2c2c;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop8789"
+         style="stop-color:#3d3d3d;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="19.244999"
+       y1="21.030804"
+       x2="19.360001"
+       gradientUnits="userSpaceOnUse"
+       y2="44.984001"
+       id="linearGradient2460">
+      <stop
+         offset="0"
+         style="stop-color:#fafafa;stop-opacity:1;"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4114-2-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0317796,0,0,1.0317796,-830.86406,592.67791)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       x1="45.447727"
+       y1="92.539597"
+       x2="45.447727"
+       y2="7.0165396"
+       id="ButtonShadow-0-1-1-5-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0058652,0,0,0.994169,100,0)">
+      <stop
+         id="stop3750-8-9-3-6-4"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-5-6-4-2-9"
+         style="stop-color:#000000;stop-opacity:0.58823532"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4112-2-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0402541,0,0,1.0402541,-837.95116,592.51825)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4110-6-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.023305,0,0,1.023305,-823.77704,592.83757)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       id="linearGradient4116-6-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0148305,0,0,1.0148305,-816.68996,592.99723)"
+       x1="1012.5133"
+       y1="484.41721"
+       x2="1006.8082"
+       y2="20.625916" />
+    <linearGradient
+       y2="20.625916"
+       x2="1006.8082"
+       y1="484.41721"
+       x1="1012.5133"
+       gradientTransform="matrix(1.0074153,0,0,1.0074153,-810.48879,593.1369)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5342-3"
+       xlink:href="#ButtonShadow-0-1-1-5-9"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3737-9"
+       id="linearGradient4084-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(778.59979,-360.55963)"
+       x1="993.43896"
+       y1="51.511765"
+       x2="988.78552"
+       y2="363.73825" />
+    <linearGradient
+       id="linearGradient3737-9">
+      <stop
+         id="stop3739-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3741-4"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4046-3"
+       id="linearGradient4086-12"
+       gradientUnits="userSpaceOnUse"
+       x1="1764.6487"
+       y1="155.59685"
+       x2="1763.6903"
+       y2="-55.941216" />
+    <linearGradient
+       id="linearGradient4046-3">
+      <stop
+         id="stop4048-7"
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4050-73"
+         style="stop-color:#ffffff;stop-opacity:0.2"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3700"
+       id="linearGradient3617"
+       y2="5.9877172"
+       x2="48"
+       y1="90"
+       x1="48" />
+    <linearGradient
+       id="linearGradient3700">
+      <stop
+         offset="0"
+         style="stop-color:#222222;stop-opacity:1"
+         id="stop3702" />
+      <stop
+         offset="1"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop3704" />
+    </linearGradient>
+    <clipPath
+       id="clipPath3805">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:none"
+         id="rect3807"
+         y="28.31978"
+         x="7.8286824"
+         ry="4.4196429"
+         rx="6"
+         height="41.668793"
+         width="80.307129" />
+    </clipPath>
+    <filter
+       id="filter3795"
+       color-interpolation-filters="sRGB">
+      <feGaussianBlur
+         stdDeviation="1.215"
+         id="feGaussianBlur3797" />
+    </filter>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3756"
+       id="linearGradient3762"
+       y2="90.001488"
+       x2="65.928574"
+       y1="6"
+       x1="65.928574" />
+    <linearGradient
+       id="linearGradient3756">
+      <stop
+         offset="0"
+         style="stop-color:#dbff9a;stop-opacity:1"
+         id="stop3758" />
+      <stop
+         offset="0.17644246"
+         style="stop-color:#dfffa7;stop-opacity:1"
+         id="stop3772" />
+      <stop
+         offset="0.29336214"
+         style="stop-color:#c1ff53;stop-opacity:1"
+         id="stop3774" />
+      <stop
+         offset="0.49318853"
+         style="stop-color:#82c50c;stop-opacity:1"
+         id="stop3776" />
+      <stop
+         offset="0.75466347"
+         style="stop-color:#609501;stop-opacity:1"
+         id="stop3764" />
+      <stop
+         offset="1"
+         style="stop-color:#7cbf06;stop-opacity:1"
+         id="stop3760" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.50000001,0,0,1,61.499999,0)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3737"
+       id="linearGradient3829"
+       y2="48"
+       x2="-35"
+       y1="48"
+       x1="-41" />
+    <linearGradient
+       id="linearGradient3737">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3739" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3741" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.66666667,0,0,1,-13.666667,0)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3819"
+       id="linearGradient3825"
+       y2="48"
+       x2="-35"
+       y1="48"
+       x1="-41" />
+    <linearGradient
+       id="linearGradient3819">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3821" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3823" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3700-3">
+      <stop
+         offset="0"
+         style="stop-color:#222222;stop-opacity:1"
+         id="stop3702-4" />
+      <stop
+         offset="1"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop3704-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3700-3"
+       id="linearGradient6862"
+       gradientUnits="userSpaceOnUse"
+       x1="48"
+       y1="90"
+       x2="48"
+       y2="5.9877172"
+       gradientTransform="matrix(5.6190476,0,0,5.6190476,-33.714286,-33.714286)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3756-6"
+       id="linearGradient3762-0"
+       y2="90.001488"
+       x2="65.928574"
+       y1="6"
+       x1="65.928574" />
+    <linearGradient
+       id="linearGradient3756-6">
+      <stop
+         offset="0"
+         style="stop-color:#dbff9a;stop-opacity:1"
+         id="stop3758-3" />
+      <stop
+         offset="0.17644246"
+         style="stop-color:#dfffa7;stop-opacity:1"
+         id="stop3772-0" />
+      <stop
+         offset="0.29336214"
+         style="stop-color:#c1ff53;stop-opacity:1"
+         id="stop3774-2" />
+      <stop
+         offset="0.49318853"
+         style="stop-color:#82c50c;stop-opacity:1"
+         id="stop3776-1" />
+      <stop
+         offset="0.75466347"
+         style="stop-color:#609501;stop-opacity:1"
+         id="stop3764-7" />
+      <stop
+         offset="1"
+         style="stop-color:#7cbf06;stop-opacity:1"
+         id="stop3760-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3756-6"
+       id="linearGradient6940"
+       gradientUnits="userSpaceOnUse"
+       x1="65.928574"
+       y1="6"
+       x2="65.928574"
+       y2="90.001488"
+       gradientTransform="matrix(5.6190476,0,0,5.6190476,-230.90774,-33.714286)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8785"
+       id="linearGradient3090-7-6"
+       gradientUnits="userSpaceOnUse"
+       x1="51.351883"
+       y1="478.81833"
+       x2="48.837971"
+       y2="31.964804" />
+    <linearGradient
+       id="linearGradient3700-3-1">
+      <stop
+         offset="0"
+         style="stop-color:#222222;stop-opacity:1"
+         id="stop3702-4-3" />
+      <stop
+         offset="1"
+         style="stop-color:#333333;stop-opacity:1"
+         id="stop3704-9-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3700-3-1"
+       id="linearGradient7538"
+       gradientUnits="userSpaceOnUse"
+       x1="48"
+       y1="90"
+       x2="48"
+       y2="5.9877172"
+       gradientTransform="translate(-20,-20)" />
+    <linearGradient
+       y2="26.936981"
+       x2="48"
+       y1="491.38788"
+       x1="53.865795"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7556"
+       xlink:href="#linearGradient3700-3"
+       inkscape:collect="always" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Livello 1"
+     transform="translate(0,-540.36218)" />
+  <g
+     id="g2036"
+     transform="matrix(1.1,0,0,0.44444,95.081063,256.39254)">
+    <g
+       id="g3712"
+       style="opacity:0.4"
+       transform="matrix(1.0526,0,0,1.2857,-1.2632,-13.429)" />
+  </g>
+  <g
+     transform="translate(97.481063,231.28154)"
+     id="g3541" />
+  <g
+     transform="translate(97.481063,231.28154)"
+     id="g3536" />
+  <g
+     id="g4103"
+     transform="translate(-11.985071,-592.11719)">
+    <rect
+       ry="101.45834"
+       y="612.11719"
+       x="31.985071"
+       height="487"
+       width="487"
+       id="rect6187"
+       style="opacity:0.1;color:#000000;fill:url(#linearGradient4114-2-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="opacity:0.07999998;color:#000000;fill:url(#linearGradient4112-2-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect6191"
+       width="491"
+       height="491"
+       x="31.985071"
+       y="612.11719"
+       ry="102.29167" />
+    <rect
+       style="opacity:0.2;color:#000000;fill:url(#linearGradient4110-6-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect6183"
+       width="483"
+       height="483"
+       x="31.985071"
+       y="612.11719"
+       ry="100.62501" />
+    <rect
+       ry="99.791664"
+       y="612.11719"
+       x="31.985071"
+       height="479"
+       width="479"
+       id="rect6179"
+       style="opacity:0.25;color:#000000;fill:url(#linearGradient4116-6-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="opacity:0.25;color:#000000;fill:url(#linearGradient5342-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5574"
+       width="475.5"
+       height="475.5"
+       x="31.985071"
+       y="612.11719"
+       ry="99.0625" />
+  </g>
+  <g
+     id="g4076"
+     transform="translate(-605.51932,-353.96833)">
+    <g
+       transform="translate(-926.66758,684.38448)"
+       id="g4038" />
+  </g>
+  <g
+     id="g8774">
+    <path
+       inkscape:connector-curvature="0"
+       id="rect5505"
+       d="M 118.34375,20 C 63.867087,20 20,63.867084 20,118.34375 l 0,23.0625 0,252.25 C 20,448.13291 63.867087,492 118.34375,492 l 275.3125,0 C 448.13292,492 492,448.13291 492,393.65625 l 0,-252.25 0,-23.0625 C 492,63.867084 448.13292,20 393.65625,20 l -275.3125,0 z"
+       style="fill:url(#linearGradient7556);stroke:none;color:#000000;fill-opacity:1;fill-rule:nonzero;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       style="fill:#8bd507;stroke:none;color:#000000;fill-opacity:1;fill-rule:nonzero;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="M 217 20 L 217 492 L 393.65625 492 C 448.13292 492 492 448.13291 492 393.65625 L 492 141.40625 L 492 118.34375 C 492 63.867084 448.13292 20 393.65625 20 L 217 20 z "
+       id="path6884" />
+  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.23529412;fill-rule:nonzero;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10"
+     d="m 229.84375,146.75 c -1.53972,0.01 -3.09945,0.0413 -4.65625,0.0937 -2.58678,0.0881 -5.14606,0.33228 -7.71875,0.53125 C 129.83054,154.41332 54,228.65625 54,228.65625 c 0,0 15.332174,44.34466 53.40625,82.46875 l 180.87495,180.8748 105.375,0 C 448.13292,492 492,448.13291 492,393.65625 l 0,-68.53125 -32.7501,-32.71865 c -4.5086,-3.7515 -9.026,-6.5168 -13.0937,-8.90625 l -73.0624,-73.06235 c -24.74667,-24.26454 -75.71142,-64.12198 -143.25,-63.6875 z m -1.3125,21.4375 c 69.76655,-0.2171 115.375,61.53125 115.375,61.53125 0,0 -50.75101,70.59375 -105.1875,70.59375 -7.83424,0 -14.92835,-1.40585 -21.25,-3.53125 l 0,-79.34375 c 27.89268,3.37036 33.6372,15.76446 50.40625,43.71875 l 37.21875,-31.625 c 0,0 -27.1682,-35.625 -73.0625,-35.625 -4.99218,0 -9.87672,0.37311 -14.5625,0.875 l 0,-26.1875 c 2.54628,-0.17785 5.09853,-0.26095 7.71875,-0.34375 1.11949,-0.0352 2.23634,-0.0591 3.34375,-0.0625 z"
+     id="path7664"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccsscccccccsccccsccccc" />
+  <g
+     id="g4076-9"
+     transform="translate(-605.51937,-353.96833)">
+    <g
+       transform="translate(-926.66758,684.38448)"
+       id="g4038-9">
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.3;color:#000000;fill:url(#linearGradient4084-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.50000000000000000;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m 1650.4994,-310.41615 c -54.4767,0 -98.3125,43.83583 -98.3125,98.3125 l 0,275.343747 c 0,54.476673 43.8358,98.343753 98.3125,98.343753 l 2.9375,0 c -53.3225,0 -96.25,-42.9275 -96.25,-96.250003 l 0,-269.499997 c 0,-53.3225 42.9275,-96.25 96.25,-96.25 l 269.5001,0 c 53.3225,0 96.25,42.9275 96.25,96.25 l 0,269.499997 c 0,53.322503 -42.9275,96.250003 -96.25,96.250003 l 2.9062,0 c 54.4767,0 98.3438,-43.86708 98.3438,-98.343753 l 0,-275.343747 c 0,-54.47667 -43.8671,-98.3125 -98.3438,-98.3125 l -275.3438,0 z"
+         id="rect6809-2-3" />
+      <path
+         id="path3981-7"
+         d="m 1650.4994,161.58385 c -54.4767,0 -98.3125,-43.83583 -98.3125,-98.312503 l 0,-275.343747 c 0,-54.47667 43.8358,-98.34375 98.3125,-98.34375 l 2.9375,0 c -53.3225,0 -96.25,42.9275 -96.25,96.25 l 0,269.499997 c 0,53.322503 42.9275,96.250003 96.25,96.250003 l 269.5001,0 c 53.3225,0 96.25,-42.9275 96.25,-96.250003 l 0,-269.499997 c 0,-53.3225 -42.9275,-96.25 -96.25,-96.25 l 2.9062,0 c 54.4767,0 98.3438,43.86708 98.3438,98.34375 l 0,275.343747 c 0,54.476673 -43.8671,98.312503 -98.3438,98.312503 l -275.3438,0 z"
+         style="opacity:0.2;color:#000000;fill:url(#linearGradient4086-12);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     style="display:inline"
+     id="layer1-1"
+     transform="matrix(5.6190476,0,0,5.6190476,565.98222,15.094507)" />
+  <path
+     id="path7505"
+     d="m -324.96875,121.40625 c 0,72.28125 0,144.5625 0,216.84375 z"
+     style="fill:#7ec206;fill-opacity:1;fill-rule:nonzero;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#7ec206;fill-opacity:1;fill-rule:nonzero;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10"
+     d="m -342.44854,-521.09456 0,130.12499 c 2.57269,-0.19897 5.13198,-0.44317 7.71876,-0.53122 99.63521,-3.35804 164.53124,81.81249 164.53124,81.81249 0,0 -74.56965,90.625 -152.25,90.625 -7.11927,0 -13.73998,-0.67365 -20,-1.78125 l 0,24.25 c 5.35315,0.67971 10.89596,1.0625 16.6875,1.0625 72.28675,0 124.5999,-36.93179 175.21875,-80.625 8.39244,6.72136 42.81203,23.05893 49.875,30.21875 -48.12894,40.29468 -160.28362,72.875 -223.87499,72.875 -6.12972,0 -12.11992,-0.50431 -17.90626,-1.0625 l 0,125.031251 241.09375,0 c 18.677706,0 33.718746,-15.041039 33.718746,-33.718753 l 0,-404.562488 c 0,-18.67772 -15.04104,-33.71875 -33.718746,-33.71875 l -241.09375,0 z m 0,346.96874 0,-22.46875 c -88.46409,-11.13065 -118.71875,-108.6875 -118.71875,-108.6875 0,0 39.59627,-58.42182 118.71875,-64.46875 l 0,-21.21875 c -87.63821,7.03832 -163.46877,81.28125 -163.46877,81.28125 0,0 42.92284,124.18533 163.46877,135.5625 z m 0,-195.625 0,26.1875 c 4.68578,-0.50189 9.57032,-0.875 14.5625,-0.875 45.8943,0 73.06251,35.625 73.06251,35.625 l -37.21875,31.625 c -16.76905,-27.95429 -22.51358,-40.34839 -50.40626,-43.71875 l 0,79.34375 c 6.32165,2.1254 13.41577,3.53125 21.25001,3.53125 54.43649,0 105.18749,-70.59375 105.18749,-70.59375 0,0 -47.07129,-63.71918 -118.71874,-61.46875 -2.62022,0.0828 -5.17248,0.16593 -7.71876,0.34378 z m 0,128.1875 c -37.6938,-12.66439 -49.87499,-56.53125 -49.87499,-56.53125 0,0 21.89254,-26.17053 49.87499,-22.8125 l 0,-22.65625 c -53.31476,5.76519 -85.34375,41.25 -85.34375,41.25 0,0 18.48591,69.54922 85.34375,81.46875 l 0,-20.71875 z"
+     id="path7507" />
+  <g
+     id="g8770">
+    <path
+       style="fill:#8bd507;fill-opacity:1;fill-rule:nonzero;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10"
+       d="m 229.84375,146.73619 c -1.53972,0.01 -3.09945,0.0413 -4.65625,0.0937 -2.58678,0.0881 -5.14606,0.33228 -7.71875,0.53125 C 129.83054,154.39946 54,228.64239 54,228.64239 c 0,0 42.922823,124.18533 163.46875,135.5625 5.78634,0.55819 11.77653,1.0625 17.90625,1.0625 63.59137,0 175.74606,-32.58032 223.875,-72.875 -7.06297,-7.15982 -41.48256,-23.49739 -49.875,-30.21875 -50.61885,43.69321 -102.932,80.625 -175.21875,80.625 -5.79154,0 -11.33435,-0.38279 -16.6875,-1.0625 l 0,-24.25 c 6.26002,1.1076 12.88073,1.78125 20,1.78125 77.68035,0 152.25,-90.625 152.25,-90.625 0,0 -62.87247,-82.53027 -159.875,-81.90625 z m -1.3125,21.4375 c 69.76655,-0.2171 115.375,61.53125 115.375,61.53125 0,0 -50.75101,70.59375 -105.1875,70.59375 -7.83424,0 -14.92835,-1.40585 -21.25,-3.53125 l 0,-79.34375 c 27.89268,3.37036 33.6372,15.76446 50.40625,43.71875 l 37.21875,-31.625 c 0,0 -27.1682,-35.625 -73.0625,-35.625 -4.99218,0 -9.87672,0.37311 -14.5625,0.875 l 0,-26.1875 c 2.54628,-0.17785 5.09853,-0.26095 7.71875,-0.34375 1.11949,-0.0352 2.23634,-0.0591 3.34375,-0.0625 z"
+       id="path7512"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient3090-7-6);stroke:none;color:#000000;fill-opacity:1.0;fill-rule:nonzero;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       d="M 229.84375 146.75 C 228.30403 146.76 226.7443 146.79135 225.1875 146.84375 C 222.60072 146.93185 220.04144 147.17603 217.46875 147.375 C 217.31231 147.38756 217.15636 147.39326 217 147.40625 L 217 364.15625 C 217.15795 364.17157 217.31054 364.20382 217.46875 364.21875 C 223.25509 364.77694 229.24528 365.28125 235.375 365.28125 C 298.96637 365.28125 411.12106 332.70093 459.25 292.40625 C 452.18703 285.24643 417.76744 268.90886 409.375 262.1875 C 358.75615 305.88071 306.443 342.8125 234.15625 342.8125 C 228.36471 342.8125 222.8219 342.42971 217.46875 341.75 L 217.46875 317.5 C 223.72877 318.6076 230.34948 319.28125 237.46875 319.28125 C 315.1491 319.28125 389.71875 228.65625 389.71875 228.65625 C 389.71875 228.65625 326.84628 146.12598 229.84375 146.75 z M 228.53125 168.1875 C 298.2978 167.9704 343.90625 229.71875 343.90625 229.71875 C 343.90625 229.71875 293.15524 300.3125 238.71875 300.3125 C 230.88451 300.3125 223.7904 298.90665 217.46875 296.78125 L 217.46875 217.4375 C 245.36143 220.80786 251.10595 233.20196 267.875 261.15625 L 305.09375 229.53125 C 305.09375 229.53125 277.92555 193.90625 232.03125 193.90625 C 227.03907 193.90625 222.15453 194.27936 217.46875 194.78125 L 217.46875 168.59375 C 220.01503 168.4159 222.56728 168.3328 225.1875 168.25 C 226.30699 168.2148 227.42384 168.1909 228.53125 168.1875 z "
+       id="path7518" />
+  </g>
+</svg>

--- a/optimus_manager/optimus_manager_systray.py
+++ b/optimus_manager/optimus_manager_systray.py
@@ -1,0 +1,162 @@
+import argparse
+import socket
+import sys
+import signal
+import traceback
+from functools import partial
+
+from PyQt5.QtWidgets import QSystemTrayIcon, QMenu, QApplication, QWidget, QMessageBox, QErrorMessage
+from PyQt5.QtGui import QIcon
+from PyQt5.QtCore import QTimer
+import optimus_manager.checks as checks
+import optimus_manager.envs as envs
+
+NVIDIA = 'nvidia'
+INTEL = 'intel'
+
+NVIDIA_ICON = QIcon.fromTheme('nvidia', QIcon('../icon/nvidia.svg'))
+INTEL_ICON = QIcon.fromTheme('intel', QIcon('../icon/intel.svg'))
+
+
+# Next 3 funcs courtesy of https://coldfix.eu/2016/11/08/pyqt-boilerplate
+
+def setup_interrupt_handling():
+    """Setup handling of KeyboardInterrupt (Ctrl-C) for PyQt."""
+    signal.signal(signal.SIGINT, _interrupt_handler)
+    # Regularly run some (any) python code, so the signal handler gets a
+    # chance to be executed:
+    safe_timer(50, lambda: None)
+
+
+def _interrupt_handler(signum, frame):
+    """Handle KeyboardInterrupt: quit application."""
+    QApplication.quit()
+
+
+def safe_timer(timeout, func, *args, **kwargs):
+    """
+    Create a timer that is safe against garbage collection and overlapping
+    calls. See: http://ralsina.me/weblog/posts/BB974.html
+    """
+
+    def timer_event():
+        try:
+            func(*args, **kwargs)
+        finally:
+            QTimer.singleShot(timeout, timer_event)
+
+    QTimer.singleShot(timeout, timer_event)
+
+
+def send_command(cmd, parent=None):
+    """Send a command to daemon."""
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        client.connect(envs.SOCKET_PATH)
+        client.send(cmd.encode('utf-8'))
+        client.close()
+
+    except (ConnectionRefusedError, OSError):
+        msg = ("Cannot connect to the UNIX socket at %s. Is optimus-manager-daemon running?\n"
+               "You can enable and start it by running these commands as root:\n"
+               "systemctl enable optimus-manager.service\n"
+               "systemctl start optimus-manager.service" % envs.SOCKET_PATH)
+        print(msg)
+        error_dialog = QErrorMessage(parent)
+        error_dialog.showMessage(msg)
+
+
+class SystemTrayIcon(QSystemTrayIcon):
+    def __init__(self, mode, parent=None):
+        self.parent = parent
+        QSystemTrayIcon.__init__(self, NVIDIA_ICON if mode == NVIDIA else INTEL_ICON, self.parent)
+        menu = QMenu(self.parent)
+
+        # Nvidia menu item bound to self.switch('nvidia')
+        nvidia_action = menu.addAction(NVIDIA_ICON, "Switch to nvidia" if mode == INTEL else "Reload nvidia")
+        nvidia_action.triggered.connect(partial(self.switch, NVIDIA))
+
+        # Intel menu item bound to self.switch('intel')
+        intel_action = menu.addAction(INTEL_ICON, "Switch to intel" if mode == NVIDIA else "Reload intel")
+        intel_action.triggered.connect(partial(self.switch, INTEL))
+
+        # Provide an easy menu item to close the "app"
+        exit_action = menu.addAction("Exit")
+        exit_action.triggered.connect(self.exit)
+
+        # Set the menu and proper tooltip
+        self.setContextMenu(menu)
+        self.setToolTip('optimus-manager ({mode})'.format(mode=mode))
+
+    def exit(self):
+        """Exit gracefully."""
+        QApplication.exit()
+
+    def confirm(self, to):
+        """Ask if user is sure they want to switch GPU."""
+        msg = QMessageBox(self.parent)
+
+        # Make a pixmap out of the proper icon and use it as the icon
+        msg.setIconPixmap((NVIDIA_ICON if to == NVIDIA else INTEL_ICON).pixmap(64, 64))
+
+        msg.setWindowTitle('WARNING: You are about to switch GPUs')
+        msg.setText("You are about to switch to the {to} GPU. "
+                    "This will restart the display manager and all your applications WILL CLOSE.\n"
+                    "Would you like to continue?".format(to=to))
+
+        yes = msg.addButton('Yes, switch GPU', QMessageBox.AcceptRole)
+        no = msg.addButton('No, cancel switch', QMessageBox.RejectRole)
+        msg.setDefaultButton(no)
+        msg.exec()
+        if msg.clickedButton() is yes:
+            return True
+        return False
+
+    def switch(self, to):
+        """Switch to a GPU after confirming."""
+        print('Confirming switch to', to)
+        if self.confirm(to):
+            print('Switching')
+            send_command(to, self.parent)
+        print('Cancelled')
+
+
+def main():
+    # Arguments parsing
+    parser = argparse.ArgumentParser(description="Daemon program for the Optimus Manager tool.\n"
+                                                 "https://github.com/Askannz/optimus-manager")
+    parser.parse_args()
+
+    print("Optimus Manager (systray) version %s" % envs.VERSION)
+
+    # Setup
+    app = QApplication(sys.argv)
+    # Make sure it doesn't quit after cancelling a confirm prompt
+    app.setQuitOnLastWindowClosed(False)
+
+    # Check current mode
+    try:
+        mode = checks.read_gpu_mode()
+        print('Current mode:', mode)
+    except checks.CheckError as e:
+        msg = "Error reading mode : %s" % str(e)
+        print(msg)
+        error_dialog = QErrorMessage()
+        error_dialog.showMessage(msg)
+        sys.exit(app.exec_())
+
+    # Setup systray
+    widget = QWidget()
+    tray_icon = SystemTrayIcon(mode, widget)
+    tray_icon.show()
+
+    # Make sure KeyboardInterrupt signals and exceptions are handled correctly
+    setup_interrupt_handling()
+    sys.excepthook = traceback.print_exception
+
+    # Start
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
             'optimus-manager=optimus_manager.optimus_manager_client:main',
             'optimus-manager-setup=optimus_manager.optimus_manager_setup:main',
             'optimus-manager-daemon=optimus_manager.optimus_manager_daemon:main',
+            'optimus-manager-systray=optimus_manager.optimus_manager_systray:main',
         ],
     },
     package_data={'optimus_manager': ['config_schema.json']},


### PR DESCRIPTION
Adds a QT systray to easily switch between GPUs.

Now depends on `python-pyqt5` - though if you wanted, it could just be optionally :)

Icons are from FlatWoken, which is released under a CC BY SA license. I'm not yet sure how to properly credit that in AUR packages? A small note in the readme might be enough?

Also requires that the .desktop file, be installed to /usr/share/applications/ in the AUR PKGBUILD.

Here's how it looks on my XFCE desktop panel:
![image](https://user-images.githubusercontent.com/3002987/50644540-6c0ca580-0f71-11e9-9572-bce2ee78846c.png)

Feel free to give any feedback/request changes before merging, I started just writing it for myself, but thought I might as well submit it upstream.
