### PR TITLE
Assign PIDs to the commands' stdout instead of the commands' processes

### DIFF
--- a/optimus_manager/xorg.py
+++ b/optimus_manager/xorg.py
@@ -25,12 +25,12 @@ def configure_xorg(config, mode):
 def get_xorg_servers_pids():
 
     try:
-        x_pids = exec_bash("pidof X")
+        x_pids = exec_bash("pidof X").stdout
     except BashError:
         x_pids = ""
 
     try:
-        xorg_pids = exec_bash("pidof Xorg")
+        xorg_pids = exec_bash("pidof Xorg").stdout
     except BashError:
         xorg_pids = ""
 


### PR DESCRIPTION
Just a bug fix. This seems to be the only reason I wasn't able to switch after the 0.7 update.