### PR TITLE
sessions: Add support for restarting DeepinDE

### DIFF
--- a/optimus_manager/sessions.py
+++ b/optimus_manager/sessions.py
@@ -32,6 +32,14 @@ def logout_current_desktop_session():
     except dbus.exceptions.DBusException:
         pass
 
+    # Deepin
+    try:
+        deepin = session_bus.get_object('com.deepin.SessionManager', '/com/deepin/SessionManager')
+        deepin.RequestLogout()
+    except dbus.exceptions.DBusException:
+        pass
+
+
 
 def is_there_a_wayland_session():
 


### PR DESCRIPTION
- Currently, optimus-manager only restarts KDE, GNOME and XFCE.
- Get deepin's dbus object and call RequestLogout() to restart the DE.

Test: Switch GPUs; Display Manager restarts and GPU switches correctly.
System Config: DeepinDE + LightDM on ArchLinux
  - iGPU: Intel HD 620
  - dGPU: NVIDIA 940 MX

Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>