### PR TITLE
Verify that /var/log/optimus-manager directory exists

### DIFF
--- a/scripts/prime-offload
+++ b/scripts/prime-offload
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-/usr/bin/python3 -u /usr/bin/optimus-manager-setup --setup-prime 2>&1 | tee -a /var/log/optimus-manager/prime_setup.log
+log_file='/var/log/optimus-manager/prime_setup.log'
+[[ ! -d $(dirname $log_file) ]] && mkdir -p $(dirname $log_file)
+
+/usr/bin/python3 -u /usr/bin/optimus-manager-setup --setup-prime 2>&1 | tee -a $log_file
 
  

--- a/scripts/prime-switch
+++ b/scripts/prime-switch
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-/usr/bin/python3 -u /usr/bin/optimus-manager-setup --setup-gpu 2>&1 | tee -a /var/log/optimus-manager/gpu_setup.log
+log_file='/var/log/optimus-manager/gpu_setup.log'
+[[ ! -d $(dirname $log_file) ]] && mkdir -p $(dirname $log_file)
+
+/usr/bin/python3 -u /usr/bin/optimus-manager-setup --setup-gpu 2>&1 | tee -a $log_file
 
  

--- a/scripts/prime-switch-boot
+++ b/scripts/prime-switch-boot
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-/usr/bin/python3 -u /usr/bin/optimus-manager-setup --setup-boot 2>&1 | tee -a /var/log/optimus-manager/boot_setup.log
+log_file='/var/log/optimus-manager/boot_setup.log'
+[[ ! -d $(dirname $log_file) ]] && mkdir -p $(dirname $log_file)
+
+/usr/bin/python3 -u /usr/bin/optimus-manager-setup --setup-boot 2>&1 | tee -a $log_file
 
  


### PR DESCRIPTION
I've seen that `prime-switch-boot` (and co. scripts) fails if the directory `/var/log/optimus-manager` doesn't exist.