### PR TITLE
add support to execute custom commands for nvidia power management

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ Some config changes will not be effective until you computer is rebooted or the 
 
 You can also add your own Xorg options in `/etc/optimus-manager/xorg-intel.conf` and `/etc/optimus-manager/xorg-nvidia.conf`. Anything you put in those files will be written to the "Device" section of the auto-generated Xorg configuration file corresponding to their respective GPU mode.
 
-Finally, if you need the display manager to run some specific commands to set up the display (to force a particular resolution, for instance), you can write them to `/etc/optimus-manager/xsetup-intel.sh` (for Intel mode) and `/etc/optimus-manager/xsetup-nvidia.sh` (for Nvidia mode).
+If you need the display manager to run some specific commands to set up the display (to force a particular resolution, for instance), you can write them to `/etc/optimus-manager/xsetup-intel.sh` (for Intel mode) and `/etc/optimus-manager/xsetup-nvidia.sh` (for Nvidia mode).
+
+Finally, if you need to run some spcific code prior to enabling or after disabling the nvidia graphics card (for example, to manually enable the card if bbswitch is not supported), you can write the commands to `/etc/optimus-manager/nvidia-pre-enable.sh` and `/etc/optimus-manager/nvidia-post-disable.sh`.
 
 FAQ / Troubleshooting
 ----------

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can also add your own Xorg options in `/etc/optimus-manager/xorg-intel.conf`
 
 If you need the display manager to run some specific commands to set up the display (to force a particular resolution, for instance), you can write them to `/etc/optimus-manager/xsetup-intel.sh` (for Intel mode) and `/etc/optimus-manager/xsetup-nvidia.sh` (for Nvidia mode).
 
-Finally, if you need to run some spcific code prior to enabling or after disabling the nvidia graphics card (for example, to manually enable the card if bbswitch is not supported), you can write the commands to `/etc/optimus-manager/nvidia-pre-enable.sh` and `/etc/optimus-manager/nvidia-post-disable.sh`.
+Finally, if you need to run some spcific code prior to enabling or after disabling the nvidia graphics card (for example, to manually enable the card if bbswitch is not supported), you can write the commands to `/etc/optimus-manager/nvidia-enable.sh` and `/etc/optimus-manager/nvidia-disable.sh`.
 
 FAQ / Troubleshooting
 ----------

--- a/config/nvidia-disable.sh
+++ b/config/nvidia-disable.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# This script is only executed if you set switching to none in optimus-manager.conf.
+# Everything you write here will be executed by optimus-manager as root after unloading the nvidia kernel modules.
+# Use this for clean up tasks and commands related to the power management of the nvidia gpu.

--- a/config/nvidia-enable.sh
+++ b/config/nvidia-enable.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# This script is only executed if you set switching to none in optimus-manager.conf.
+# Everything you write here will be executed by optimus-manager as root prior to loading the nvidia kernel modules.
+# Use this to enable the gpu using custom commands or to execute commands related to the power management of the nvidia gpu.

--- a/optimus-manager.conf
+++ b/optimus-manager.conf
@@ -7,7 +7,8 @@
 # - bbswitch : power off the card using the bbswitch module (requires the bbswitch dependency).
 # - acpi_call : try various ACPI method calls to power the card on and off (requires the acpi_call dependency)
 # - none : do not use an external module for power management. For some laptop models it's preferable to
-#           use this option in combination with pci_power_control (see below).
+#           use this option in combination with pci_power_control (see below). You can use the scipts
+#           nvidia-enable.sh and nvidia-disable.sh to execute custom commands for power management.
 switching=nouveau
 
 # Enable PCI power management in Intel mode.

--- a/optimus_manager/envs.py
+++ b/optimus_manager/envs.py
@@ -23,6 +23,9 @@ EXTRA_XORG_OPTIONS_NVIDIA_PATH = "/etc/optimus-manager/xorg-nvidia.conf"
 XSETUP_SCRIPT_INTEL = "/etc/optimus-manager/xsetup-intel.sh"
 XSETUP_SCRIPT_NVIDIA = "/etc/optimus-manager/xsetup-nvidia.sh"
 
+NVIDIA_MANUAL_ENABLE_SCRIPT = "/etc/optimus-manager/nvidia-enable.sh"
+NVIDIA_MANUAL_DISABLE_SCRIPT = "/etc/optimus-manager/nvidia-disable.sh"
+
 LOG_DIR_PATH = "/var/log/optimus-manager/"
 BOOT_SETUP_LOGFILE_NAME = "boot_setup.log"
 PRIME_SETUP_LOGFILE_NAME = "prime_setup.log"

--- a/optimus_manager/kernel.py
+++ b/optimus_manager/kernel.py
@@ -102,7 +102,7 @@ def _set_base_state(config):
     # - bbswitch state to ON if bbswitch is loaded
     # - PCI power state to "on"
 
-    _unload_nvidia_modules(config)
+    _unload_nvidia_modules()
     _unload_nouveau()
 
     if not pci.is_nvidia_visible():
@@ -161,7 +161,7 @@ def _load_nvidia_modules(config):
     except BashError as e:
         raise KernelSetupError("Cannot load Nvidia modules : %s" % str(e))
 
-def _unload_nvidia_modules(config):
+def _unload_nvidia_modules():
 
     print("Unloading Nvidia modules")
 

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Robin Lange <robin dot langenc at gmail dot com>
 # Contributor: Robin Lange <robin dot langenc at gmail dot com>
 pkgname=optimus-manager-git
-pkgver=1.1.r29.g8b281e3
+pkgver=1.1
 pkgrel=1
 pkgdesc="Management utility to handle GPU switching for Optimus laptops (Git version)"
 arch=('any')

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Robin Lange <robin dot langenc at gmail dot com>
 # Contributor: Robin Lange <robin dot langenc at gmail dot com>
 pkgname=optimus-manager-git
-pkgver=1.1
+pkgver=1.1.r29.g8b281e3
 pkgrel=1
 pkgdesc="Management utility to handle GPU switching for Optimus laptops (Git version)"
 arch=('any')
@@ -18,6 +18,8 @@ backup=('etc/optimus-manager/xorg-intel.conf'
         'etc/optimus-manager/xorg-nvidia.conf'
         'etc/optimus-manager/xsetup-intel.sh'
         'etc/optimus-manager/xsetup-nvidia.sh'
+        'etc/optimus-manager/nvidia-enable.sh'
+        'etc/optimus-manager/nvidia-disable.sh'
         'var/lib/optimus-manager/startup_mode'
         'var/lib/optimus-manager/requested_mode')
 source=("git+https://github.com/Askannz/optimus-manager.git#branch=master")
@@ -64,6 +66,9 @@ package() {
   
   install -Dm755 config/xsetup-intel.sh "$pkgdir/etc/optimus-manager/xsetup-intel.sh"
   install -Dm755 config/xsetup-nvidia.sh "$pkgdir/etc/optimus-manager/xsetup-nvidia.sh"
+
+  install -Dm755 config/nvidia-enable.sh "$pkgdir/etc/optimus-manager/nvidia-enable.sh"
+  install -Dm755 config/nvidia-disable.sh "$pkgdir/etc/optimus-manager/nvidia-disable.sh"
  
   python3 setup.py install --root="$pkgdir/" --optimize=1 --skip-build
  


### PR DESCRIPTION
hi,
This PR enables users to execute custom commands via two new script files (nvidia-enable.sh / nvidia-disable.sh) when using switching=none. This enables users of devices on which bbswitch isn't working to manually enable or disable the gpu by executing custom commands before loading or after unloading the nvidia kernel modules.