### PR TITLE
Adding a way to set the IgnoreABI flag on the NVIDIA driver

### DIFF
--- a/optimus-manager.conf
+++ b/optimus-manager.conf
@@ -82,6 +82,10 @@ PAT=yes
 # Leave blank for the default (the above command will not be run).
 DPI=96
 
+# If you're running an updated version of xorg-server (let's say to get PRIME Render offload enabled),
+# the nvidia driver may not load because of an ABI version mismatch. Setting this flag to "yes"
+# will allow the loading of the nvidia driver.
+ignore_abi=
 
 # Comma-separated list of Nvidia-specific options to apply.
 # Available options :

--- a/optimus_manager/config_schema.json
+++ b/optimus_manager/config_schema.json
@@ -22,6 +22,7 @@
 		"modeset": ["single_word", ["yes", "no"], false],
 		"pat": ["single_word", ["yes", "no"], false],
 		"dpi": ["integer", true],
+		"ignore_abi": ["single_word", ["yes", "no"], true],
 		"options": ["multi_words", ["overclocking", "triple_buffer"], true]
 	}
 }

--- a/optimus_manager/xorg.py
+++ b/optimus_manager/xorg.py
@@ -145,6 +145,8 @@ def _generate_nvidia(config, bus_ids, xorg_extra):
             "\tDevice \"intel\"\n" \
             "EndSection\n\n"
 
+    text += _make_server_flags_section(config, bus_ids, xorg_extra)
+
     return text
 
 
@@ -174,6 +176,8 @@ def _generate_hybrid(config, bus_ids, xorg_extra):
            "\tIdentifier \"nvidia\"\n" \
            "\tDevice \"nvidia\"\n" \
            "EndSection\n\n"
+
+    text += _make_server_flags_section(config, bus_ids, xorg_extra)
 
     return text
 
@@ -222,6 +226,15 @@ def _make_intel_device_section(config, bus_ids, xorg_extra):
     text += "EndSection\n\n"
 
     return text
+
+def _make_server_flags_section(config, bus_ids, xorg_extra):
+    if config["nvidia"]["ignore_abi"] == "yes":
+        return (
+            "Section \"ServerFlags\"\n"
+            "\tOption \"IgnoreABI\" \"1\"\n"
+            "EndSection\n\n"
+        )
+    return ""
 
 def _write_xorg_conf(xorg_conf_text):
 


### PR DESCRIPTION
Using the PRIME Render offload by NVIDIA (see [this doc](https://download.nvidia.com/XFree86/Linux-x86_64/435.17/README/primerenderoffload.html)) needs the latest xorg-server (which can be installed from the AUR with the packages `xorg-server-git` and `xorg-server-common-git`). But this will prevent the nvidia driver from loading up because of an ABI version mismatch.

This PR adds an `ignore_abi` in the NVIDIA settings that will add the proper server flags in the xorg.conf file. When used, the ABI version mismatch is ignored by the nvidia driver and it loads up fully, allowing anyone to now use NVIDIA PRIME Render offload with the proper environment variables. 