### PR TITLE
implement `ac_auto` option for connected ac power

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Usage
 Run
 * `optimus-manager --switch nvidia` to switch to the Nvidia GPU
 * `optimus-manager --switch intel` to switch to the Intel GPU and power the Nvidia GPU off
-* `optimus-manager --switch hybrid` to switch to the Intel GPU but leave the Nvidia GPU available for on-demand offloading, similar to how Optimus works on Windows. See [the Wiki](https://github.com/Askannz/optimus-manager/wiki/Nvidia-GPU-offloading-for-%22hybrid%22-mode) for more details.
-* `optimus-manager --switch ac_auto` to switch to the Nvidia GPU when connected to AC and `ac_auto_battery_mode` from the config when disconnected
+* `optimus-manager --switch hybrid` to switch to the Intel GPU but leave the Nvidia GPU available for on-demand offloading, similar to how Optimus works on Windows. See [the Wiki](https://github.com/Askannz/optimus-manager/wiki/Nvidia-GPU-offloading-for-%22hybrid%22-mode) for more details
+* `optimus-manager --switch ac_auto` to switch to `ac_auto_extpower_mode` from the config when connected to AC and `ac_auto_battery_mode` when disconnected
 * `optimus-manager --switch auto` to automatically detect which mode you are currently running and auto-switch to another (will switch to `intel` if you are in `nvidia` or `hybrid` mode, and to `nvidia` otherwise)
 
 *WARNING :* Switching mode automatically logs you out, so make sure you save your work and close all your applications before doing so.

--- a/optimus-manager.conf
+++ b/optimus-manager.conf
@@ -44,6 +44,10 @@ auto_logout=yes
 # Possible values : intel, hybrid
 ac_auto_battery_mode=intel
 
+# The mode used with startup mode ac_auto when connected to AC.
+# Possible values : hybrid, nvidia
+ac_auto_extpower_mode=nvidia
+
 [intel]
 
 # Driver to use for the Intel GPU. Possible values : modesetting, intel

--- a/optimus_manager/config_schema.json
+++ b/optimus_manager/config_schema.json
@@ -6,7 +6,8 @@
 		"pci_remove": ["single_word", ["yes", "no"], false],
 		"pci_reset": ["single_word", ["no", "function_level", "hot_reset"], false],
 		"auto_logout": ["single_word", ["yes", "no"], false],
-		"ac_auto_battery_mode": ["single_word", ["intel", "hybrid"], false]
+		"ac_auto_battery_mode": ["single_word", ["intel", "hybrid"], false],
+		"ac_auto_extpower_mode": ["single_word", ["hybrid", "nvidia"], false]
 	},
 
 	"intel":

--- a/optimus_manager/optimus_manager_setup.py
+++ b/optimus_manager/optimus_manager_setup.py
@@ -154,8 +154,8 @@ def _get_startup_mode(config):
 
     if startup_mode == "ac_auto":
         print("Startup mode is ac_auto, determining mode to set")
-        ac_auto_battery_option = config["optimus"]["ac_auto_battery_mode"]
-        startup_mode = "nvidia" if is_ac_power_connected() else ac_auto_battery_option
+        ac_auto_battery_option, ac_auto_extpower_option = config["optimus"]["ac_auto_battery_mode"], config["optimus"]["ac_auto_extpower_mode"]
+        startup_mode = ac_auto_extpower_option if is_ac_power_connected() else ac_auto_battery_option
 
     return startup_mode
 


### PR DESCRIPTION
While the most recent change  introduced the `ac_auto` mode and made it
possible to select a mode to be used when  booting on battery power, it
would probably be useful to have the mode for external power configura-
ble too, e. g. to enable a 'Intel GPU on battery power / Hybrid mode on
ac-power' setup.

This commit adds an according setting to  the config file, accepting as
value either `hybrid` or `nvidia`. Further, the `README.md` file is ex-
tended to document this new option.