### PR TITLE
Autologout: add support for LXDE

### DIFF
--- a/optimus_manager/sessions.py
+++ b/optimus_manager/sessions.py
@@ -67,6 +67,12 @@ def logout_current_desktop_session():
     except BashError:
         pass
 
+    # lxde
+    try:
+        exec_bash("pkill -SIGTERM -f lxsession")
+    except BashError:
+        pass
+
 
 def is_there_a_wayland_session():
 


### PR DESCRIPTION
Hello,

Thanks a lot for optimus-manager. I discovered it recently, it works great and it's well documented.

I use LXDE and I'd love for optimus-manager to handle auto logout for it. So here is some sample code to logout from LXDE.

As I'm not a python developer I don't know how to test this though, so I just added this via the GitHub UI… 

PS: as a side note, I tried making optimus-manager work with LXDM (LXDE display manager) without success. I may be wrong here, but I concluded it was not possible, because of the way the [event-based scripts](https://wiki.archlinux.org/index.php/LXDM#Configuration) are handled by LXDM. I ended up switching to LightDM and it worked perfectly. If you think saying that in the docs would be useful I'd be happy to add a note somewhere, let me know.