### PR TITLE
Make entering 'n' or nothing when trying to switch GPUs return a return code of 1

### DIFF
--- a/optimus_manager/client/__init__.py
+++ b/optimus_manager/client/__init__.py
@@ -80,6 +80,8 @@ def _gpu_switch(config, switch_mode, no_confirm):
 
         if confirmation:
             _send_switch_command(config, switch_mode)
+        else:
+            sys.exit(1)
 
     else:
         _send_switch_command(config, switch_mode)


### PR DESCRIPTION
I was getting a little annoyed when I accidentally press enter on my optimus-manager scripts and still continuing execution despite getting aborted, so I thought I'd make this pull request.