### PR TITLE
fix exception because of non-existent dict key

### DIFF
--- a/optimus_manager/xorg.py
+++ b/optimus_manager/xorg.py
@@ -130,7 +130,7 @@ def _get_xsetup_script_path(requested_mode):
                 script_name = "integrated"
 
         else:
-            script_name = "amd"
+            script_name = "integrated"
 
     elif requested_mode == "nvidia":
         script_name = "nvidia"


### PR DESCRIPTION
This should fix the exception mentioned in :
https://github.com/Askannz/optimus-manager/issues/109#issuecomment-707358215

The exception is thrown because `envs.XSETUP_SCRIPTS_PATHS` doesn't implement a dict element with `amd` key (since there is no xsetup-script for amd). So let's use `integrated` instead.