### PR TITLE
Allow use of xorg driver in nvidia mode for AMD/NVIDIA

### DIFF
--- a/optimus_manager/checks.py
+++ b/optimus_manager/checks.py
@@ -47,6 +47,18 @@ def get_active_renderer():
     else:
         return "integrated"
 
+def get_integrated_provider():
+
+    try:
+        provider = exec_bash("xrandr --listproviders")
+    except BashError as e:
+        raise CheckError("Cannot list xrandr provdiers : %s")
+
+    for line in re.findall("name:.*", provider):
+        for _p in line.split("name:")[1].split():
+            if _p == "AMD":
+                return line.split("name:")[1]
+
 
 def is_module_available(module_name):
 

--- a/optimus_manager/hooks/post_xorg_start.py
+++ b/optimus_manager/hooks/post_xorg_start.py
@@ -3,6 +3,7 @@ from ..config import load_config
 from .. import var
 from ..xorg import do_xsetup, set_DPI
 from ..log_utils import set_logger_config, get_logger
+from ..pci import get_gpus_bus_ids
 
 
 def main():
@@ -24,8 +25,9 @@ def main():
 
         requested_mode = prev_state["requested_mode"]
 
-        do_xsetup(requested_mode)
         config = load_config()
+        bus_ids = get_gpus_bus_ids()
+        do_xsetup(requested_mode, config, bus_ids)
         set_DPI(config)
 
         state = {


### PR DESCRIPTION
on AMD/NVIDIA devices, Since they cannot use PRIME Sync: `eDP-1-0 PRIME Synchronization: 0`, this is a workaround for tearing using the xf86-video-amdgpu driver's TearFree option. We regex the provider string because the amdgpu driver isn't a simple one word line like 'Intel', rather something like this 'Unknown AMD Radeon GPU @ pci:0000:06:00.0'