### PR TITLE
Added new startup_mode "auto_nvdisplay"

### DIFF
--- a/optimus-manager.conf
+++ b/optimus-manager.conf
@@ -40,9 +40,12 @@ pci_reset=no
 auto_logout=yes
 
 # GPU mode to use at computer startup.
-# Possible values: nvidia, integrated, hybrid, auto, intel (deprecated, equivalent to integrated)
+# Possible values: nvidia, integrated, hybrid, auto, auto_nvdisplay, intel (deprecated, equivalent to integrated)
 # "auto" is a special mode that auto-detects if the computer is running on battery
-# and selects a proper GPU mode. See the other options below.
+# and selects a proper GPU mode.
+# "auto_nvdisplay" sets the GPU mode based on whether a display is connected directly to the nvidia GPU,
+# which can be useful if any display output works only in a specific mode.
+# See the other options below.
 startup_mode=integrated
 # GPU mode to select when startup_mode=auto and the computer is running on battery.
 # Possible values: nvidia, integrated, hybrid, intel (deprecated, equivalent to integrated)
@@ -50,6 +53,12 @@ startup_auto_battery_mode=integrated
 # GPU mode to select when startup_mode=auto and the computer is running on external power.
 # Possible values: nvidia, integrated, hybrid, intel (deprecated, equivalent to integrated)
 startup_auto_extpower_mode=nvidia
+# GPU mode to select when startup_mode=auto_nvdisplay and no display is connected directly to the nvidia GPU.
+# Possible values: nvidia, integrated, hybrid
+startup_auto_nvdisplay_off_mode=integrated
+# GPU mode to select when startup_mode=auto_nvdisplay and a display is connected directly to the nvidia GPU.
+# Possible values: nvidia, integrated, hybrid
+startup_auto_nvdisplay_on_mode=nvidia
 
 
 [intel]

--- a/optimus_manager/checks.py
+++ b/optimus_manager/checks.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from ctypes import byref, POINTER, c_uint, Structure, c_int, c_void_p, CDLL
 import re
 import dbus
 import psutil
@@ -27,6 +28,46 @@ def is_ac_power_connected():
 
         except IOError:
             continue
+
+    return False
+
+
+class NvCfgPciDevice(Structure):
+    _fields_ = [("domain", c_int), ("bus", c_int), ("slot", c_int), ("function", c_int)]
+
+
+NvCfgPciDevicePtr = POINTER(NvCfgPciDevice)
+
+
+def is_nvidia_display_connected():
+    num_gpus = c_int()
+    gpus = NvCfgPciDevicePtr()
+
+    try:
+        nvcfg_lib = CDLL("libnvidia-cfg.so")
+    except OSError:
+        raise CheckError("Failed to open 'libnvidia-cfg.so'. Is package 'nvidia-utils' installed?")
+
+    if nvcfg_lib.nvCfgGetPciDevices(byref(num_gpus), byref(gpus)) != 1:
+        return False
+
+    for i in range(num_gpus.value):
+        device_handle = c_void_p()
+
+        try:
+            if nvcfg_lib.nvCfgOpenPciDevice(gpus[i].domain, gpus[i].bus, gpus[i].slot,
+                                            c_int(0), byref(device_handle)) != 1:
+                continue
+
+            mask = c_uint()
+            if nvcfg_lib.nvCfgGetDisplayDevices(device_handle, byref(mask)) != 1:
+                continue
+
+            if mask.value != 0:
+                return True
+
+        finally:
+            nvcfg_lib.nvCfgCloseDevice(device_handle)  # ignores if the function fails
 
     return False
 

--- a/optimus_manager/config_schema.json
+++ b/optimus_manager/config_schema.json
@@ -7,9 +7,11 @@
 		"pci_reset": ["single_word", ["no", "function_level", "hot_reset"], false],
 		"auto_logout": ["single_word", ["yes", "no"], false],
 
-		"startup_mode": ["single_word", ["integrated", "hybrid", "nvidia", "auto", "intel"], false],
+		"startup_mode": ["single_word", ["integrated", "hybrid", "nvidia", "auto", "auto_nvdisplay", "intel"], false],
 		"startup_auto_battery_mode": ["single_word", ["integrated", "hybrid", "nvidia"], false],
-		"startup_auto_extpower_mode": ["single_word", ["integrated", "hybrid", "nvidia"], false]
+		"startup_auto_extpower_mode": ["single_word", ["integrated", "hybrid", "nvidia"], false],
+		"startup_auto_nvdisplay_off_mode": ["single_word", ["integrated", "hybrid", "nvidia"], false],
+		"startup_auto_nvdisplay_on_mode": ["single_word", ["integrated", "hybrid", "nvidia"], false]
 	},
 
 	"intel":

--- a/optimus_manager/hooks/pre_daemon_start.py
+++ b/optimus_manager/hooks/pre_daemon_start.py
@@ -2,7 +2,7 @@ import sys
 from ..config import load_config, copy_user_config
 from .. import var
 from ..xorg import cleanup_xorg_conf
-from ..checks import is_ac_power_connected
+from ..checks import is_ac_power_connected, is_nvidia_display_connected
 from ..kernel_parameters import get_kernel_parameters
 from ..log_utils import set_logger_config, get_logger
 
@@ -39,6 +39,12 @@ def main():
                 eff_startup_mode = config["optimus"]["startup_auto_extpower_mode"]
             else:
                 eff_startup_mode = config["optimus"]["startup_auto_battery_mode"]
+            logger.info("Effective startup mode is: %s", eff_startup_mode)
+        elif startup_mode == "auto_nvdisplay":
+            if is_nvidia_display_connected():
+                eff_startup_mode = config["optimus"]["startup_auto_nvdisplay_on_mode"]
+            else:
+                eff_startup_mode = config["optimus"]["startup_auto_nvdisplay_off_mode"]
             logger.info("Effective startup mode is: %s", eff_startup_mode)
         else:
             eff_startup_mode = startup_mode

--- a/package/PKGBUILD
+++ b/package/PKGBUILD
@@ -13,7 +13,8 @@ depends=('python3' 'python-setuptools' 'python-dbus' 'mesa-demos' 'xorg-xrandr'
          'python-psutil')
 optdepends=('bbswitch: alternative power switching method'
             'acpi_call: alternative power switching method'
-            'xf86-video-intel: provides the Xorg intel driver')
+            'xf86-video-intel: provides the Xorg intel driver',
+            'nvidia-utils: allows use of auto_nvdisplay startup_mode')
 makedepends=('python-setuptools' 'git')
 backup=('etc/optimus-manager/xorg/integrated-mode/integrated-gpu.conf'
         'etc/optimus-manager/xorg/nvidia-mode/integrated-gpu.conf'


### PR DESCRIPTION
Allows setting the effective startup mode based on whether a display is connected to the nvidia GPU directly.
This happens before the nvidia driver is potentially unloaded, using the shared library 'libnvidia-cfg.so' that is provided by the nvidia-utils package.
The mode is useful for laptops where the external display outputs are wired to the discrete GPU resulting in any external display not working in intel mode.

I'm happy to integrate any suggestions and feedback.

One thing I want to mention is that while testing my changes on my machine, I sometimes got stuck at the plymouth splash screen when rebooting with an external display connected after optimus-manager had an error before (because of an invalid config, etc.). I am not sure what causes this since I found no indications of any error in my journal.