### PR TITLE
Improve startup time by using "modinfo -n" to detect modules

### DIFF
--- a/optimus_manager/checks.py
+++ b/optimus_manager/checks.py
@@ -57,7 +57,7 @@ def get_active_renderer():
 def is_module_available(module_name):
 
     return subprocess.run(
-        f"modinfo {module_name}",
+        f"modinfo -n {module_name}",
         shell=True, stdout=subprocess.DEVNULL
     ).returncode == 0
 


### PR DESCRIPTION
I analyzed the journal and code of optimus-manager and found that a large amout of time is wasted by `modinfo` in `checks.py`, which can be very slow if used without any parameter. I replaced it with `modinfo -n` and the startup time was improved from ~6s to ~1s on my laptop.