### PR TITLE
Update qtile logout command

### DIFF
--- a/optimus_manager/sessions.py
+++ b/optimus_manager/sessions.py
@@ -51,7 +51,7 @@ def logout_current_desktop_session():
         "bspc quit",  # bspwm
         "pkill -SIGTERM -f dwm",  # dwm
         "pkill -SIGTERM -f lxsession",  # LXDE
-        "qtile-cmd -o cmd -f shutdown"  # qtile
+        "qtile cmd-obj -o cmd -f shutdown"  # qtile
     ]:
         try:
             check_call(cmd, shell=True)


### PR DESCRIPTION
Qtile has changed the way their cmd works.

Currently on both stable and latest qtile, optimus-manager returns ```Unknown command: qtile-cmd```

More info on ```qtile cmd-obj```:
http://docs.qtile.org/en/latest/manual/commands/shell/qtile-cmd.html (latest)
http://docs.qtile.org/en/stable/manual/commands/shell/qtile-cmd.html (stable)
