### PR TITLE
Fix Auto logout Command for Qtile Window Manager

### DIFF
--- a/optimus_manager/sessions.py
+++ b/optimus_manager/sessions.py
@@ -51,7 +51,7 @@ def logout_current_desktop_session():
         "bspc quit",  # bspwm
         "pkill -SIGTERM -f dwm",  # dwm
         "pkill -SIGTERM -f lxsession",  # LXDE
-        "qtile-cmd -o cmd -f shutdown"  # qtile
+        "qtile cmd-obj -o cmd -f shutdown"  # qtile
     ]:
         try:
             check_call(cmd, shell=True)


### PR DESCRIPTION
qtile-cmd is now refactored into "qtile cmd-obj". So using qtile-cmd throws "command not found".

relavant commit: https://github.com/qtile/qtile/commit/0b62fbe95b0042a3a579cae96d729682fd3817da#diff-810067998eae6cb260e48c1804d5b6358ac202ea26f1ac06aeb1492d520d8f95
qtile docs reference: https://docs.qtile.org/en/latest/manual/commands/shell/qtile-cmd.html
