### PR TITLE
Fixed link to config file on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Run
 
 Auto-logout is supported for the following desktop environments/window managers: KDE Plasma, Gnome, XFCE, Deepin, i3, Openbox, AwesomeWM, bspwm, dwm, LXDE, QTile. You can disable this feature in the configuration file. In that case, the GPU switch will not be effective until the next login.
 
-You can also specify which GPU you want to be used by default when the system boots, by setting `startup_mode` in the [configuration file][optimus-manager.conf](optimus-manager.conf) at `/etc/optimus-manager/optimus-manager.conf`.
+You can also specify which GPU you want to be used by default when the system boots, by setting `startup_mode` in the [configuration file](https://github.com/Askannz/optimus-manager/blob/master/optimus-manager.conf) at `/etc/optimus-manager/optimus-manager.conf`.
 
 Note that switching to and from "integrated" mode can be a little unstable, due to having to load/unload the nvidia kernel modules and change the power state of the card. If you're experiencing stability issues, the safest way to use this mode is to boot straight into it using the `startup_mode` config options or the kernel parameter (see below).
 


### PR DESCRIPTION
Not sure if this is what you meant to write, but the current format looks a bit off IMO.

P.S. IDK how to propose edits to the Wiki, but I think it would be great to add a link to https://github.com/Askannz/optimus-manager/wiki/A-guide--to-power-management-options on [this section](https://github.com/Askannz/optimus-manager/wiki/A-guide--to-power-management-options#configuration-1--dynamic-power-management-inside-the-nvidia-driver-runtime-d3-power-management), particularly when mentioning how one could read the config file for the difference between `fine` and `coarse`. Not sure how it got to this point, but the config file I initially got had none of those comments.