### PR TITLE
use new logout method for kde5+

### DIFF
--- a/optimus_manager/sessions.py
+++ b/optimus_manager/sessions.py
@@ -20,8 +20,12 @@ def logout_current_desktop_session():
     else:
 
         def logout_kde():
-            kde = session_bus.get_object("org.kde.ksmserver", "/KSMServer")
-            kde.logout(0, 3, 3, dbus_interface="org.kde.KSMServerInterface")
+            try:
+                kde = session_bus.get_object("org.kde.Shutdown", "/Shutdown")
+                kde.logout()
+            except:
+                kde = session_bus.get_object("org.kde.ksmserver", "/KSMServer")
+                kde.closeSession(0, 3, 3, dbus_interface="org.kde.KSMServerInterface")
         def logout_gnome():
             gnome = session_bus.get_object("org.gnome.SessionManager", "/org/gnome/SessionManager")
             gnome.Logout(1, dbus_interface="org.gnome.SessionManager")


### PR DESCRIPTION
My X11 session was not automatically restarting with KDE. After some searching I found this reddit thread which hinted at a new interface in dbus.
https://github.com/jonaspleyer/optimus-manager
The changes should hopefully still work in KDE4 and less. I was not sure how to detect the version of KDE and would gladly have done this instead.

I am happy about feedback.