### PR TITLE
Added a hybrid driver mode for xorg integrated driver

### DIFF
--- a/optimus-manager.conf
+++ b/optimus-manager.conf
@@ -63,13 +63,15 @@ startup_auto_nvdisplay_on_mode=nvidia
 
 [intel]
 
-# Driver to use for the Intel GPU. Possible values : modesetting, intel
+# Driver to use for the Intel GPU. Possible values : modesetting, intel, hybrid
 # To use the intel driver, you need to install the package "xf86-video-intel".
+# If you want to use the intel driver only in integrated mode and modesetting for 
+# nvidia mode, use "hybrid" driver.
 driver=modesetting
 
 # Acceleration method (corresponds to AccelMethod in the Xorg configuration).
 # Only applies to the intel driver.
-# Possible values : sna, xna, uxa
+# Possible values : sna, xna, uxa, none
 # Leave blank for the default (no option specified)
 accel=
 
@@ -79,7 +81,8 @@ accel=
 # Leave blank for the default (no option specified)
 tearfree=
 
-# DRI version. Possible values : 2, 3
+# DRI version. Possible values : 2, 3, 0
+# To omit the option, specify 0
 DRI=3
 
 # Whether or not to enable modesetting for the nouveau driver.
@@ -90,8 +93,10 @@ modeset=yes
 
 [amd]
 
-# Driver to use for the AMD GPU. Possible values : modesetting, amdgpu
+# Driver to use for the AMD GPU. Possible values : modesetting, amdgpu, hybrid
 # To use the amdgpu driver, you need to install the package "xf86-video-amdgpu".
+# If you want to use the amdgpu driver only in integrated mode and modesetting for 
+# nvidia mode, use "hybrid" driver.
 driver=modesetting
 
 # Enable TearFree option in the Xorg configuration.
@@ -100,7 +105,8 @@ driver=modesetting
 # Leave blank for the default (no option specified)
 tearfree=
 
-# DRI version. Possible values : 2, 3
+# DRI version. Possible values : 2, 3, 0
+# To omit the option, specify 0
 DRI=3
 
 

--- a/optimus_manager/config_schema.json
+++ b/optimus_manager/config_schema.json
@@ -16,18 +16,18 @@
 
 	"intel":
 	{
-		"driver": ["single_word", ["modesetting", "intel"], false],
-		"accel": ["single_word", ["sna", "xna", "uxa"], true],
+		"driver": ["single_word", ["modesetting", "intel", "hybrid"], false],
+		"accel": ["single_word", ["sna", "xna", "uxa", "none"], true],
 		"tearfree": ["single_word", ["yes", "no"], true],
-		"dri": ["single_word", ["2", "3"], false],
+		"dri": ["single_word", ["0", "2", "3"], false],
 		"modeset": ["single_word", ["yes", "no"], false]
 	},
 
 	"amd":
 	{
-		"driver": ["single_word", ["modesetting", "amdgpu"], false],
+		"driver": ["single_word", ["modesetting", "amdgpu", "hybrid"], false],
 		"tearfree": ["single_word", ["yes", "no"], true],
-		"dri": ["single_word", ["2", "3"], false]
+		"dri": ["single_word", ["0", "2", "3"], false]
 	},
 
 	"nvidia":


### PR DESCRIPTION
I had this problem that when I switched to NVIDIA mode and logged out, SDDM was just black and my screen was completely off (even its backlight was turned off). I had experience with `nvidia-xrun` and its default configuration always worked for me. The only way for `optimus-manager` to work, was to only use "integrated" and "hybrid" modes.

After comparing xorg configurations from `optimus-manager` and `nvidia-xrun`, it turned out that `nvidia-xrun` always uses `modesetting` as driver for "integrated" GPU, while `optimus-manager` had no option to "use intel driver when in integrated mode, use modesetting when in NVIDIA mode".

This pull request adds a "hybrid" driver for integrated GPUs that has solved the problem for me.

One would just set the `driver` option for `intel` to `hybrid` to enable this behavior. Also omitting DRI version may help too. (didn't check if it has any effect, but added this as an option too)
```
[intel]
driver=hybrid
dri=0
```