### PR TITLE
change the kde plasma logout service call

### DIFF
--- a/optimus_manager/sessions.py
+++ b/optimus_manager/sessions.py
@@ -20,8 +20,8 @@ def logout_current_desktop_session():
     else:
 
         def logout_kde():
-            kde = session_bus.get_object("org.kde.ksmserver", "/KSMServer")
-            kde.logout(0, 3, 3, dbus_interface="org.kde.KSMServerInterface")
+            kde = session_bus.get_object("org.kde.Shutdown", "/Shutdown")
+            kde.logout()
         def logout_gnome():
             gnome = session_bus.get_object("org.gnome.SessionManager", "/org/gnome/SessionManager")
             gnome.Logout(1, dbus_interface="org.gnome.SessionManager")


### PR DESCRIPTION
@es20490446e 
Hello, apologies for my bad english.
I just found out that after an update to kde plasma 6, the autologout function wont work anymore on my machine. The output of my `journalctl` show : 

`ArchLinux ksmserver[29637]: qt.dbus.integration: QDBusConnection: couldn't handle call to logout, no slot matched`
`ArchLinux ksmserver[29637]: qt.dbus.integration: Could not find slot KSMServerInterfaceAdaptor::logout`

Then i found out that the new plasma 6 deprecated the old ksmserver API for the logout method : 
[https://discuss.kde.org/t/logout-reboot-and-shutdown-using-the-terminal/743/9](https://discuss.kde.org/t/logout-reboot-and-shutdown-using-the-terminal/743/9)

So i just modified and updated the logout call API from using ksmserver to Shutdown, and now this works great now on plasma 6.