### PR TITLE
fix: do not leave shell dirty

### DIFF
--- a/profile.d/optimus-manager.sh
+++ b/profile.d/optimus-manager.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-set -e
 
 if [[ "${XDG_SESSION_TYPE}" == "wayland" ]]; then
 	export __NV_PRIME_RENDER_OFFLOAD=1


### PR DESCRIPTION
When having a login shell (`bash -l`) the profile.d script was leaving the user shell in a dirty state. Causing any non 0 exit codes to exit the user shell.
